### PR TITLE
Fix 2024 report typos

### DIFF
--- a/annualreports/2024.md
+++ b/annualreports/2024.md
@@ -1,5 +1,5 @@
 ---
-name:  2023 Annual report and 2024 plans
+name: 2023 Annual report and 2024 plans
 date: 2023-03-20
 title: 2023 Annual report and 2024 plans
 description: Report of the 2023 activities of the FPA and plans for 2024
@@ -28,7 +28,7 @@ We have **upgraded the FPA to get VAT**. With this, the FPA is now able to buy g
 
 ### Strategic goals
 
-The FPA has defined, discussed and advanced on a series of **strategic goals** that we wanted to incentive, with the idea of a version 1.0 in mind: 
+The FPA has defined, discussed and advanced on a series of **strategic goals** that we wanted to incentive, with the idea of a version 1.0 in mind:
 
 * Resolution of the Toponaming issue
 * Having a default Assembly workbench
@@ -56,13 +56,13 @@ In 2023, the FPA has organized two meetings, one in [Vancouver](https://blog.fre
 
 ### New members
 
-The FPA [roster](https://fpa.freecad.org/handbook/people/roster.html) has expanded, a few members have chosen to remain inactive, while new members have joined. The chirman has also been reelected for a 2-year period.
+The FPA [roster](https://fpa.freecad.org/handbook/people/roster.html) has expanded, a few members have chosen to remain inactive, while new members have joined. The chairman has also been re-elected for a 2-year period.
 
 ### Financial Report
 
-2023 was our first year of formal double entry bookkeeping.  This has provided greater insight into our financial situation and allowed us to easily comply with regulations.
+2023 was our first year of formal double entry bookkeeping. This has provided greater insight into our financial situation and allowed us to easily comply with regulations.
 
-In 2023, the FPA received donations of just over **€100,000**.  This amount exceeded our expectations.  The donations continue to come mainly from individuals in small amounts (less than €10).  We did note an increase in recurring donations from individuals.  Support from businesses increased in 2024, but remains a small portion of total revenue.
+In 2023, the FPA received donations of just over **€100,000**. This amount exceeded our expectations. The donations continue to come mainly from individuals in small amounts (less than €10). We did note an increase in recurring donations from individuals. Support from businesses increased but remains a small portion of total revenue.
 
 ![Donations per Donor](/images/2024DonationsPerDonor.svg)
 
@@ -76,10 +76,10 @@ The FPA used four donation platforms in 2024:
 
 * direct deposits to our bank account
 * transfers to our PayPal account
-* Github donations
+* GitHub donations
 * donations via Open Collective.
 
-As far as we can determine, the BountySource donation platform has ceased operations and the FPA expects to write off our BountySource balance of approximately 4,000 USD in 2024.  We have engaged a lawyer to pursue our rights in this matter, but we are not optimistic about a successful resolution.
+As far as we can determine, the BountySource donation platform has ceased operations and the FPA expects to write off our BountySource balance of approximately 4,000 USD in 2024. We have engaged a lawyer to pursue our rights in this matter, but we are not optimistic about a successful resolution.
 
 ![Donations by Funding Platform](/images/2024DonationsByPlatform.svg)
 
@@ -93,7 +93,7 @@ The FPA spent approximately **€26,000** in 2023 with the majority being spend 
 
 ### Debts
 
-As of the end of 2023, the FPA had a total debt of €20.  This amount represents an accounting error related to mentor stipends for the Google Summer of Code and will be corrected in the January 2024 accounting period, leaving the FPA completely debt free.
+As of the end of 2023, the FPA had a total debt of €20. This amount represents an accounting error related to mentor stipends for the Google Summer of Code and will be corrected in the January 2024 accounting period, leaving the FPA completely debt free.
 
 
 ### Non-financial Assets
@@ -171,15 +171,15 @@ We expect 2024 to be even busier than 2023. We plan therefore to take some addit
 ### 2024 Budget Estimate
 
 #### Income
-  
-We expect our 2024 income from all sources to be higher that 2023, just as donations in 2023 were higher than 2022.  Projecting 2023 Q3 and Q4 revenue across 2024, we should see an income of over €100,000.
+
+We expect our 2024 income from all sources to be higher that 2023, just as donations in 2023 were higher than 2022. Projecting 2023 Q3 and Q4 revenue across 2024, we should see an income of over €100,000.
 
 #### Expenses
-  
-We increased our spending in all areas in 2023, particularly in the second half of the year, and expect this to continue in 2024.  We improved our handling of grant proposals and our approach to soliciting grantees in 2023, although we did not reach planned spending levels. The lessons learned in 2023 will improve our ability to meet spending targets in 2024.
-  
+
+We increased our spending in all areas in 2023, particularly in the second half of the year, and expect this to continue in 2024. We improved our handling of grant proposals and our approach to soliciting grantees in 2023, although we did not reach planned spending levels. The lessons learned in 2023 will improve our ability to meet spending targets in 2024.
+
 Projected spending in 2024:
-  
+
 * FPADF - €50,000
 * Event support - €10,000
 * Reserve fund - €20,000


### PR DESCRIPTION
Hi there,
Just some small typo fixes on the FPA 2024 report.
Also please beware of double spaces: depending on the Markdown parser, they can be converted to line breaks (official way). The Markdown library Jekyll uses does not do that though.
Thanks.