### PR TITLE
More Responsive Menu 

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -455,3 +455,11 @@ td:not(:last-child), th:not(:last-child) {
         color: $OffBlack;
     }
 }
+@media (max-width: 768px) {
+  #menuContainer {
+    flex-direction: column;
+    align-items: center;
+    margin-top:3em;
+    margin-bottom:1em;
+  }
+}


### PR DESCRIPTION
A breakpoint was added to ensure this. It was intended to be a completely quick solution. It is nice not to use breakpoints in any way to make the site responsive, but it has to start somewhere. I think @maxwxyz mentioned this problem on Discord.
Before:
![Screenshot 2024-06-09 at 16-10-18 FPA](https://github.com/FreeCAD/FPA/assets/39885728/eb3572a6-9fc2-41ce-aec3-ed7d205adde1)
After:
![Screenshot 2024-06-09 at 16-10-56 FPA](https://github.com/FreeCAD/FPA/assets/39885728/a29f6f27-7f04-4364-93e2-bc2cca427408)
Both screenshots were taken for the same width.