### PR TITLE
[Responsive]Center the list menu on the screen

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -239,6 +239,7 @@ $time: 0.8s;
     padding: 0;
     font-size: 20px;
     text-align: left;
+    justify-content: center;
     li {
         > span {
             padding: 1em;


### PR DESCRIPTION
At first, I thought this problem only existed on small screens, but it turns out that this problem exists on all screen sizes. I added more than one screenshot because it completely changes the overall behavior. You can try this center-position method on a relatively new, you can try an older ancient method. It also has a different appearance and can be used according to preference. To avoid confusion, I am not sharing its screenshots, but I am leaving the code below.

```
.menuList > li {
  position: relative;
  margin: auto;
}
```

Before:
![resim](https://github.com/FreeCAD/FPA/assets/39885728/ccabe8fe-71d4-43f0-9217-a5bf7616f7dd)
After:
![resim](https://github.com/FreeCAD/FPA/assets/39885728/6a4a00b1-92ec-47ac-95ba-99a6da4b85a3)

Before:
![resim](https://github.com/FreeCAD/FPA/assets/39885728/b8b15908-2ecc-4eef-b225-5eb37816b60c)
After:
![resim](https://github.com/FreeCAD/FPA/assets/39885728/6fbd38be-0543-46ae-bc16-94d0cbc4d68c)

Before:
![resim](https://github.com/FreeCAD/FPA/assets/39885728/2d8b286b-0a98-473e-83d9-dd2f56a57792)
After:
![resim](https://github.com/FreeCAD/FPA/assets/39885728/272eea71-e486-4f10-bb47-ea36e95d645f)
