### PR TITLE
[Responsive] Fixing responsive issues caused by overflow.

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -19,6 +19,7 @@ body {
     margin: 0 auto;
     padding: 0 50px;
     overflow-y: scroll;
+    overflow-wrap: break-word;
     font-family: "Inter", sans-serif;
     font-weight: 350;
     font-size: 18px;


### PR DESCRIPTION
It's a very hard problem to notice. It's very long and requires a group of adjacent letters, and chrominum is a browser. Firefox doesn't have this problem. With this change, it won't be in chrome anymore.
Before:
![screencapture-fpa-freecad-org-handbook-process-grant-program-rules-html-2024-09-19-18_53_37](https://github.com/user-attachments/assets/e089e58d-1e78-4924-8dcf-cb6df1915992)
After:
![screencapture-fpa-freecad-org-handbook-process-grant-program-rules-html-2024-09-19-18_54_18](https://github.com/user-attachments/assets/b3352d88-62ef-4032-ae42-d259d1c40626)
