### PR TITLE
Add copyright information to core logo SVG files

### DIFF
--- a/images/logos/FreeCAD-symbol-mono.svg
+++ b/images/logos/FreeCAD-symbol-mono.svg
@@ -39,6 +39,11 @@
             <dc:title>The FreeCAD project association AISBL (FPA)</dc:title>
           </cc:Agent>
         </dc:publisher>
+        <dc:rights>
+	  <cc:Agent>
+	    <dc:title>Copyright (c) 2024 The FreeCAD Project Association AISBL. All rights reserved. For usage information please see https://freecad.org/about/logo.</dc:title>
+          </cc:Agent>
+        </dc:rights>
       </cc:Work>
     </rdf:RDF>
   </metadata>

--- a/images/logos/FreeCAD-symbol-mono.svg
+++ b/images/logos/FreeCAD-symbol-mono.svg
@@ -40,11 +40,26 @@
           </cc:Agent>
         </dc:publisher>
         <dc:rights>
-	  <cc:Agent>
-	    <dc:title>Copyright (c) 2024 The FreeCAD Project Association AISBL. All rights reserved. For usage information please see https://freecad.org/about/logo.</dc:title>
+          <cc:Agent>
+            <dc:title>Copyright (c) 2024 The FreeCAD Project Association AISBL.</dc:title>
           </cc:Agent>
         </dc:rights>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
       </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
     </rdf:RDF>
   </metadata>
 </svg>

--- a/images/logos/FreeCAD-symbol.svg
+++ b/images/logos/FreeCAD-symbol.svg
@@ -43,10 +43,24 @@
         <dc:description>A white letter F on a background that is split diagonally in half, blue on the bottom with a shape of a gear and red on the top.</dc:description>
         <dc:rights>
 	  <cc:Agent>
-	    <dc:title>Copyright (c) 2024 The FreeCAD Project Association AISBL. All rights reserved. For usage information please see https://freecad.org/about/logo.</dc:title>
+            <dc:title>Copyright (c) 2024 The FreeCAD Project Association AISBL.</dc:title>
           </cc:Agent>
         </dc:rights>
+        <cc:license rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
       </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
     </rdf:RDF>
   </metadata>
   <path

--- a/images/logos/FreeCAD-symbol.svg
+++ b/images/logos/FreeCAD-symbol.svg
@@ -6,11 +6,19 @@
    fill="none"
    version="1.1"
    id="svg4"
+   sodipodi:docname="FreeCAD-symbol.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview10"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"/>
   <title
      id="title4">FreeCAD-symbol</title>
   <defs
@@ -33,6 +41,11 @@
         </dc:publisher>
         <dc:date>2024-06-01</dc:date>
         <dc:description>A white letter F on a background that is split diagonally in half, blue on the bottom with a shape of a gear and red on the top.</dc:description>
+        <dc:rights>
+	  <cc:Agent>
+	    <dc:title>Copyright (c) 2024 The FreeCAD Project Association AISBL. All rights reserved. For usage information please see https://freecad.org/about/logo.</dc:title>
+          </cc:Agent>
+        </dc:rights>
       </cc:Work>
     </rdf:RDF>
   </metadata>

--- a/images/logos/FreeCAD-wordmark-light.svg
+++ b/images/logos/FreeCAD-wordmark-light.svg
@@ -37,6 +37,11 @@
             <dc:title>The FreeCAD project association AISBL (FPA)</dc:title>
           </cc:Agent>
         </dc:publisher>
+        <dc:rights>
+	  <cc:Agent>
+	    <dc:title>Copyright (c) 2024 The FreeCAD Project Association AISBL. All rights reserved. For usage information please see https://freecad.org/about/logo.</dc:title>
+          </cc:Agent>
+        </dc:rights>
       </cc:Work>
     </rdf:RDF>
   </metadata>

--- a/images/logos/FreeCAD-wordmark-light.svg
+++ b/images/logos/FreeCAD-wordmark-light.svg
@@ -39,10 +39,25 @@
         </dc:publisher>
         <dc:rights>
 	  <cc:Agent>
-	    <dc:title>Copyright (c) 2024 The FreeCAD Project Association AISBL. All rights reserved. For usage information please see https://freecad.org/about/logo.</dc:title>
+            <dc:title>Copyright (c) 2024 The FreeCAD Project Association AISBL.</dc:title>
           </cc:Agent>
         </dc:rights>
+        <cc:license rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
       </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
+
     </rdf:RDF>
   </metadata>
   <g

--- a/images/logos/FreeCAD-wordmark-mono-light.svg
+++ b/images/logos/FreeCAD-wordmark-mono-light.svg
@@ -44,6 +44,11 @@
             <dc:title>The FreeCAD project association AISBL (FPA)</dc:title>
           </cc:Agent>
         </dc:publisher>
+        <dc:rights>
+	  <cc:Agent>
+	    <dc:title>Copyright (c) 2024 The FreeCAD Project Association AISBL. All rights reserved. For usage information please see https://freecad.org/about/logo.</dc:title>
+          </cc:Agent>
+        </dc:rights>
       </cc:Work>
     </rdf:RDF>
   </metadata>

--- a/images/logos/FreeCAD-wordmark-mono-light.svg
+++ b/images/logos/FreeCAD-wordmark-mono-light.svg
@@ -46,10 +46,24 @@
         </dc:publisher>
         <dc:rights>
 	  <cc:Agent>
-	    <dc:title>Copyright (c) 2024 The FreeCAD Project Association AISBL. All rights reserved. For usage information please see https://freecad.org/about/logo.</dc:title>
+            <dc:title>Copyright (c) 2024 The FreeCAD Project Association AISBL.</dc:title>
           </cc:Agent>
         </dc:rights>
+        <cc:license rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
       </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
     </rdf:RDF>
   </metadata>
 </svg>

--- a/images/logos/FreeCAD-wordmark-mono.svg
+++ b/images/logos/FreeCAD-wordmark-mono.svg
@@ -39,10 +39,24 @@
         </dc:publisher>
         <dc:rights>
 	  <cc:Agent>
-	    <dc:title>Copyright (c) 2024 The FreeCAD Project Association AISBL. All rights reserved. For usage information please see https://freecad.org/about/logo.</dc:title>
+            <dc:title>Copyright (c) 2024 The FreeCAD Project Association AISBL.</dc:title>
           </cc:Agent>
         </dc:rights>
+        <cc:license rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
       </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
     </rdf:RDF>
   </metadata>
   <path

--- a/images/logos/FreeCAD-wordmark-mono.svg
+++ b/images/logos/FreeCAD-wordmark-mono.svg
@@ -37,6 +37,11 @@
             <dc:title>The FreeCAD project association AISBL (FPA)</dc:title>
           </cc:Agent>
         </dc:publisher>
+        <dc:rights>
+	  <cc:Agent>
+	    <dc:title>Copyright (c) 2024 The FreeCAD Project Association AISBL. All rights reserved. For usage information please see https://freecad.org/about/logo.</dc:title>
+          </cc:Agent>
+        </dc:rights>
       </cc:Work>
     </rdf:RDF>
   </metadata>

--- a/images/logos/FreeCAD-wordmark.svg
+++ b/images/logos/FreeCAD-wordmark.svg
@@ -39,10 +39,24 @@
         </dc:publisher>
         <dc:rights>
 	  <cc:Agent>
-	    <dc:title>Copyright (c) 2024 The FreeCAD Project Association AISBL. All rights reserved. For usage information please see https://freecad.org/about/logo.</dc:title>
+            <dc:title>Copyright (c) 2024 The FreeCAD Project Association AISBL.</dc:title>
           </cc:Agent>
         </dc:rights>
+        <cc:license rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
       </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+      </cc:License>
     </rdf:RDF>
   </metadata>
   <g

--- a/images/logos/FreeCAD-wordmark.svg
+++ b/images/logos/FreeCAD-wordmark.svg
@@ -37,6 +37,11 @@
             <dc:title>The FreeCAD project association AISBL (FPA)</dc:title>
           </cc:Agent>
         </dc:publisher>
+        <dc:rights>
+	  <cc:Agent>
+	    <dc:title>Copyright (c) 2024 The FreeCAD Project Association AISBL. All rights reserved. For usage information please see https://freecad.org/about/logo.</dc:title>
+          </cc:Agent>
+        </dc:rights>
       </cc:Work>
     </rdf:RDF>
   </metadata>


### PR DESCRIPTION
EDIT: Changed from "All rights reserved" to "CC-BY-4.0", as discussed below.

---

This PR adds the Dublin Core "Rights" and "License" fields to the main SVG files, explicitly expressing that the logo is copyright 2024 by The FreeCAD Project Association AISBL. It sets the license to CC-BY-4.0, and includes all of the metadata characterizing the rights that license encapsulates, e.g.:
```xml
        <dc:rights>
          <cc:Agent>
            <dc:title>Copyright (c) 2024 The FreeCAD Project Association AISBL.</dc:title>
          </cc:Agent>
        </dc:rights>
        <cc:license rdf:resource="http://creativecommons.org/licenses/by/4.0/" />
```
and
```xml
      <cc:License
         rdf:about="http://creativecommons.org/licenses/by/4.0/">
        <cc:permits
           rdf:resource="http://creativecommons.org/ns#Reproduction" />
        <cc:permits
           rdf:resource="http://creativecommons.org/ns#Distribution" />
        <cc:requires
           rdf:resource="http://creativecommons.org/ns#Notice" />
        <cc:requires
           rdf:resource="http://creativecommons.org/ns#Attribution" />
        <cc:permits
           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
      </cc:License>
```