### PR TITLE
Image Correction of overflowing

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -62,6 +62,10 @@ nav {
     gap: 0.4em;
 }
 
+img {
+    max-width: 100%;
+}
+
 .transistion {
     color: white;
     transition: background-color 0.4s, color 0.4s;


### PR DESCRIPTION
Especially the problem of overflowing images, which are problems with mobile, is to correct the problem quickly.

I think it should be merge before the 2025 report is published, @yorikvanhavre.

Before:
![resim](https://github.com/user-attachments/assets/24b06e22-947f-408a-a332-0cae4bbb98f6)
After:
![resim](https://github.com/user-attachments/assets/2a82c927-e1f6-4928-adf2-cf8a8e456377)
