### PR TITLE
Responsive Table

### DIFF
--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -393,6 +393,8 @@ footer {
 
 table {
     border-collapse: collapse;
+    display: block;
+    overflow-x: auto;
 }
 
 th {


### PR DESCRIPTION
Before:
![resim](https://github.com/user-attachments/assets/a429158b-cde6-44ff-8734-843b8ffd052d)
After:
![resim](https://github.com/user-attachments/assets/260ebd15-ccf7-47b3-b724-0f3f6d8eea0c)

I have reduced the width too much so that the difference can be better understood in the pictures, but this is a classic method of responsive the paintings. I don't think there's a problem with merging @yorikvanhavre.