### PR TITLE
Remove LiberaPay from the list of methods as it's not managed by the FPA

### DIFF
--- a/index.md
+++ b/index.md
@@ -74,7 +74,6 @@ The FPA is registered in Belgium as an AISBL with VAT number [BE0781867807](http
 * [Bank account: BE04 0019 2896 4531](https://wiki.freecadweb.org/Donate)
 * [PayPal](https://www.paypal.com/donate/?hosted_button_id=M3Z8BGW6DB69Q)
 * [OpenCollective](https://opencollective.com/freecad)
-* [LiberaPay team account (not managed by the FPA)](https://liberapay.com/FreeCAD/)
 * [Stripe](https://donate.stripe.com/14k3ei9TYgwFclq145)
 * [GitHub](https://github.com/sponsors/FreeCAD)
   {: .menuList .newWindow}


### PR DESCRIPTION
This addresses a valid point raised in https://forum.freecad.org/viewtopic.php?t=97686