### PR TITLE
Grant Cancellation Due to Lack of Communication

### DIFF
--- a/handbook/process/grant-program-rules.md
+++ b/handbook/process/grant-program-rules.md
@@ -135,7 +135,7 @@ For ecosystem projects, we expect you to align with maintainers of those project
 The FPA reserves the right to terminate a grant in the following cases:
 
 * The grant acceptee failed to complete the next stage of work entirely.
-* The grant acceptee abruptly stopped the work without warning.
+* The grant acceptee abruptly stopped the work without warning, **or failed to undertake any activity or to contact FPA for 90 (ninety) consecutive days from the date of their last activity or communication (in which case the budget allocated for the proposal will be automatically cancelled).**
 * The quality of code is inconsistent with credentials provided in the grant application.
 
 The FPA can still issue a partial payment for an incomplete stage. The prerequisites for that are:


### PR DESCRIPTION
The provision on cancelling a grant because of lack of communication has been clarified. During the meeting, a 180-day limit was initially proposed, but it was later agreed that a 90-day period is more suitable. The following transitional clause has been added:

For grants approved before the effective date of this amendment, the 90-day period shall start running as of the date this amendment enters into force.

Original suggested statement:
If the applicant fails to undertake any activity or to contact FPA within 90 (ninety) days from the date of their last activity related to the submitted grant proposal or their last communication with FPA, the budget allocated for the proposal shall be automatically cancelled from FPA’s budget