### PR TITLE
Maintainer Honorarium

### DIFF
--- a/_programs/maintainer_honorarium.md
+++ b/_programs/maintainer_honorarium.md
@@ -1,0 +1,19 @@
+## Maintainer Honorarium
+
+This text establishes a trust-based honorarium mechanism to compensate members of FreeCAD’s Core Maintainer group for code review, release coordination, and similar efforts, while keeping documentation burdens to a minimum. As a rule, only Core Maintainers benefit from the program; maintainers of plugins and dependencies in the FreeCAD ecosystem (“Ecosystem Maintainers”) may also be included under the special provisions below.
+
+Core Maintainers may apply for the Fixed Monthly Honorarium on any day of the year. Once the application reaches and is seen by the FPA, it is deemed accepted automatically without any vote or further approval; participation begins on that date and continues until 31 December of the same calendar year. A participant may withdraw at any time; withdrawal does not affect prior periods. No fixed payments may be claimed for months prior to inclusion. Fixed payments for months after acceptance in which the participant was active may be claimed later in aggregate.
+
+Ecosystem Maintainers may apply, once per calendar year, to be covered by the Fixed Monthly Honorarium; each such application is voted by the FPA on a per-person basis. If accepted, the person benefits until 31 December of that year; acceptance does not carry over and requires a fresh application and vote each year. In addition, all Additional Honorarium Requests by Ecosystem Maintainers—regardless of amount—are subject to FPA voting.
+
+The Fixed Monthly Honorarium is €200 (two hundred) per month. To be payable for a given month, the participant must have had at least one interaction with any FreeCAD repository in that month; purely automated/bot actions do not count. If there is no activity in a month, no fixed payment is made for that month, though the participant’s program status continues through year-end.
+
+A participant may also submit an Additional Honorarium Request. No timesheet is required; the participant states only the total additional amount requested. A €40/hour rate is a reference for internal consistency and scaling. Additional requests are independent of the fixed payment and may be submitted even if no fixed payment is taken. An Additional Honorarium Request may be made only for the current month and the immediately preceding month, and no more than one additional request may be made for any calendar month.
+
+For Core Maintainers, if the total monthly amount requested (fixed plus any additional) is €1,000 or less, it is paid without a vote; if it exceeds €1,000, the payment is voted by the FPA. For Ecosystem Maintainers, coverage under the fixed honorarium always requires an FPA vote, and thereafter every additional request is voted by the FPA irrespective of amount.
+
+Monthly requests may be submitted during the month or in the following month. The fixed monthly honorarium may be claimed in arrears, in aggregate for months after acceptance in which the participant was active. Payments are made by the FPA via a payment method determined with due regard to the participant’s stated preferences. Explanatory notes or links are not required; however, in the interests of transparency they are encouraged.
+
+The program rests on unconditional trust in the Core Maintainers Group and in each participant; statements are presumed accurate unless and until proven otherwise. An allegation of abuse does not prevent payment, and the FPA does not entertain such allegations; if raised, they must be referred to the Core Maintainers Group for assessment.
+
+To finance the program, the FPA may allocate a dedicated fund. If the fund proves insufficient, the FPA reserves the right to provide additional funding or to discontinue the program. The program operates on a calendar-year basis and is reviewed at year-end with community feedback; amounts, thresholds, and procedures may be adjusted as needed.


### PR DESCRIPTION
Abstract(By ChatGPT)

> The text sets up a trust-based honorarium for FreeCAD’s Core Maintainers to compensate code review, release coordination, and similar work with minimal paperwork. Core Maintainers can join any day; acceptance is automatic upon FPA receipt and lasts until December 31, with a fixed honorarium of €200/month payable only if there’s at least one non-bot repo interaction that month (fixed payments for active months after acceptance may be claimed later in aggregate). Participants may also file a single Additional Honorarium Request per month for only the current or immediately preceding month—no timesheet—using €40/hour as a reference. For Core Maintainers, total monthly requests (fixed + additional) up to €1,000 are paid without a vote; amounts above €1,000 require an FPA vote. Ecosystem Maintainers can be covered by the fixed honorarium only via an annual FPA vote (renewed yearly), and all their additional requests always require voting. Requests can be submitted during the month or the next; the FPA pays via an agreed method, and notes are optional but encouraged. The program presumes unconditional trust and does not pause payments due to allegations (which are referred to the Core Maintainers Group); it is financed by an FPA fund that may be topped up or discontinued if insufficient, and it runs on a calendar-year basis with year-end review and possible adjustments.

Explanation

I have been thinking about this for a long time and have looked into practices in both open source projects and academia. The proposal below is a more mature and streamlined version of my original idea: a trust-based honorarium scheme that keeps paperwork to a minimum.

Let me start with the fixed honorarium. This is a common approach, but in many projects it drifts into something salary like, which is not sustainable. As the FPA, I do not believe we can shoulder that kind of ongoing burden. In a few examples I found more workable figures. Taking inspiration from Homebrew’s practice of paying maintainers USD 300 per month, and considering both broad accessibility and the euro to dollar exchange rate, I set the fixed amount at EUR 200. To qualify, I required only a very simple activity condition: at least one interaction within the month. That threshold is intentionally light, and even minimal contribution counts as activity.

I also reviewed how peer review is handled in academia. Token based models did not seem persuasive. By contrast, I saw debates and some implementations, especially in medical journals, around paying roughly USD 50 per hour. Building on that, I added an additional honorarium path for months when maintainers feel they contributed beyond the fixed amount. Here, EUR 40 per hour serves only as an internal reference rate for consistency. No one needs to submit hours; the requester states only the total additional amount.

Everything rests on mutual good faith. A maintainer can receive up to EUR 1,000 in total for a month without any vote; amounts above that go to an FPA vote. I have also left a door open for maintainers from the broader ecosystem of plugins and dependencies. For them, inclusion under the fixed honorarium is subject to an annual FPA vote, and every additional honorarium request, regardless of amount, also goes to a vote. In this way, the core enjoys a smooth, low friction process, while ecosystem participation proceeds with a bit more oversight.