### PR TITLE
Added bugfix rewards program

### DIFF
--- a/_programs/bugfix-rewards-program.md
+++ b/_programs/bugfix-rewards-program.md
@@ -1,0 +1,24 @@
+# Bugfix Rewards Program
+
+
+
+The FreeCAD Project Association (FPA) is introducing an experimental rewards program to thank contributors who improve the reliability and stability of FreeCAD.
+
+The rules are simple: fix 5 confirmed issues from the [FreeCAD GitHub issue tracker](https://github.com/FreeCAD/FreeCAD/issues) and receive a reward of €250. The initial fund is limited to €5,000 and will be reevaluated by the FPA upon depletion.
+
+Here is how this works.
+
+1. Identify issues that qualify: each one should be in the tracker, with the “Status: Confirmed” tag, marked as either “Type: Bug” or “Type: Regression”.
+2. Submit a pull request for each issue and collaborate with maintainers on potential improvements in your patches.
+3. Once you have 5 patches merged within the last 12 weeks, create a new issue in the [FPA tracker](https://github.com/FreeCAD/FPA/issues), include links to 5 qualifying GitHub issues you resolved, and provide links to the commits or pull requests where your fixes were merged.
+4. The FPA reviews your submission and does the payout.
+5. Submit further reward requests, provided each one involves a new set of qualifying fixes.
+
+There are two limitations left to mention:
+
+- Rewards will not be retroactively granted for qualifying PR’s merged before the date of this announcement.
+- Rewards will not be awarded if the qualifying issue was caused by the same person who resolved it. If the issue is older than 6 months, this limitation no longer applies.
+
+We are hopeful that this pilot program will be successful, after which we will review the budget and adjust the rules and limitations to ensure fair treatment.
+
+To all contributors: keep being awesome!

--- a/programs.md
+++ b/programs.md
@@ -20,6 +20,9 @@ shortcuts:
     - text: The FPA seeks people interested in obtaining a grant to perform a specific task
       button: Job offers
       href: /programs/job-offers
+    - text: The FPA offers a reward to people fixing known bugs in FreeCAD (experimental program)
+      button: Bugfix rewards
+      href: /programs/bugfix-rewards-program
 ---
 
 # {{page.title}}


### PR DESCRIPTION
Simply copied the text from https://blog.freecad.org/2025/08/14/pilot-bugfix-rewards-program/ to the FPA programs section...