### PR TITLE
fix: correct broken links to grant program

### DIFF
--- a/_programs/job_offers.md
+++ b/_programs/job_offers.md
@@ -12,13 +12,13 @@ layout: default
 
 The mission of the [FreeCAD project association](https://fpa.freecad.org) (FPA) is to gather donations and spend that money on behalf of the FreeCAD project and the community. The FPA is not directly responsible for developing FreeCAD. That is the job of the community of developers who are working on FreeCAD. At the FPA, our responsibility is to help developers develop. Therefore, it is important to understand the primary goal of the money gathered by the FPA is to **help FreeCAD developers**. Funding priority will always be given to existing and active FreeCAD community members.
 
-One of the funding programs developed by the FPA is the [Grants program](FPADF-Announcement.md). The grants program allows any FreeCAD developer who feels money could help them to do a better job with FreeCAD to request an amount of money to perform a certain task.
+One of the funding programs developed by the FPA is the [Grants program](fpadf-announcement). The grants program allows any FreeCAD developer who feels money could help them to do a better job with FreeCAD to request an amount of money to perform a certain task.
 
-Alongside the [Grants program](FPADF-Announcement.md), the FPA also sponsors specific positions and tasks designed to help the overall FreeCAD development process. Below are the current open positions. If you are interested in one of these programs, send us an email at fpa@freecad.org. Make sure you read all the requirements below!
+Alongside the [Grants program](fpadf-announcement), the FPA also sponsors specific positions and tasks designed to help the overall FreeCAD development process. Below are the current open positions. If you are interested in one of these programs, send us an email at fpa@freecad.org. Make sure you read all the requirements below!
 
 ## Current open positions
 
-There are no current open positions. Please consider [applying for a Grant](FPADF-Announcement.md)!
+There are no current open positions. Please consider [applying for a Grant](fpadf_announcement)!
 
 #### **How to Apply**
 
@@ -81,4 +81,3 @@ The conditions below apply to all job offers:
 ## Current contracts
 
 The list of people currently under contract with the FPA is publicly available [on the FPA GitHub account](https://github.com/FreeCAD/FPA/issues?q=is%3Aissue%20state%3Aopen%20label%3AContract)
-

--- a/handbook/process/fundsaccess.md
+++ b/handbook/process/fundsaccess.md
@@ -23,7 +23,7 @@ Funding for items over 100 USD must be put to a vote of the General Membership f
 
 ## Grant program
 
-The FPA is distributing money to FreeCAD developers through its [grant program](../../_programs/FPADF_Announcement.md). FreeCAD contributors wishing to obtain money from the FPA to help them to contribute must do so through the grant program.
+The FPA is distributing money to FreeCAD developers through its [grant program](../../programs/fpadf-announcement). FreeCAD contributors wishing to obtain money from the FPA to help them to contribute must do so through the grant program.
 
 Working on FreeCAD is always, primarily and fundamentally, a voluntary act. One should never expect to receive any kind of monetary compensation for the work they have already done on FreeCAD. In other words, one cannot ask money for pull requests they have already done. To obtain an FPA grant, a contributor must comply with the FPA grant program rules, which require them to submit a proposal that describes the work to be done.
 
@@ -45,28 +45,28 @@ Contractor positions are typically created by the FPA itself and advertised via 
 
 The FreeCAD Project Association occasionally receives requests from teams (e.g., robotics clubs, engineering student groups, or other academic project teams) seeking sponsorship to attend events, competitions, or related activities. While we welcome opportunities to support communities using FreeCAD, the following criteria must be met for sponsorship consideration:
 
-1. **Clear and Tangible Benefit to FreeCAD**  
+1. **Clear and Tangible Benefit to FreeCAD**
     Sponsorship will only be provided where there is a demonstrable benefit to the FreeCAD project and community. General visibility, such as placing the FreeCAD logo on a banner or event listing, is not sufficient.
 
-2. **Expected Contributions**  
+2. **Expected Contributions**
     Applicants must propose concrete deliverables that highlight their use of FreeCAD and contribute to the project’s visibility or knowledge base. Examples include, but are not limited to:
 
-   * A series of blog posts or articles describing their design process with FreeCAD.  
-   * Tutorials, walkthroughs, or demonstrations of how FreeCAD was applied to their project.  
+   * A series of blog posts or articles describing their design process with FreeCAD.
+   * Tutorials, walkthroughs, or demonstrations of how FreeCAD was applied to their project.
    * Recorded presentations, videos, or educational content shared under open-access terms.
 
-3. **Alignment with Community Values**  
+3. **Alignment with Community Values**
     Sponsored projects should demonstrate an educational or community-building purpose, align with FreeCAD’s open-source principles, and be suitable for sharing with the wider FreeCAD user base.
 
-4. **Sponsorship Scope**  
+4. **Sponsorship Scope**
     The form and amount of sponsorship will be determined on a case-by-case basis, depending on available resources and the potential value of the contributions to the FreeCAD community.
 
-5. **Application Process**  
+5. **Application Process**
     Requests must include a clear proposal outlining:
 
-   * The event or activity to be sponsored.  
-   * The planned deliverables and timeline.  
-   * The expected benefit to FreeCAD.  
+   * The event or activity to be sponsored.
+   * The planned deliverables and timeline.
+   * The expected benefit to FreeCAD.
       Proposals without specific, measurable contributions will not be considered.
 
 


### PR DESCRIPTION
## Summary

Fix https://fpa.freecad.org/programs/FPADF-Announcement.md -> https://fpa.freecad.org/programs/fpadf-announcement

## Details

- these links were 404'ing at https://fpa.freecad.org/programs/FPADF-Announcement.md
  - the correct link, as in the [programs](https://fpa.freecad.org/programs.html) [page](https://github.com/FreeCAD/FPA/blob/8450ed76f449075b45ae0d9dc2b75aa5e9190930/programs.md?plain=1#L13) is https://fpa.freecad.org/programs/fpadf-announcement
  
## Validation

- I manually tested this running Jekyll locally and confirmed that the links work now