### PR TITLE
fix(programs): correct formatting of no jekyll links

### DIFF
--- a/programs.md
+++ b/programs.md
@@ -37,12 +37,12 @@ shortcuts:
 {% comment %} only render if not jekyll {% endcomment %}
 {% if false %}
 
-* (Travel grants)[/_programs/fosdem_travel_grants.md]: Travel grants for FreeCAD community members
-* (Development fund)[/_programs/FPADF_Announcement.md]: The FPA offers grants to accelerate FreeCAD development
-* (Learning initiative)[/_programs/learning_initiative.md]: A program for people willing to learn and teach FreeCAD
-* (Blog content)[/_programs/blog_content.md]: The FPA seeks authors to write original content for the FreeCAD Blog
-* (Job offers)[/_programs/job_offers.md]: The FPA seeks people interested in obtaining a grant to perform a specific task
-* (Bugfix rewards) [/_programs/bugfix_rewards_program.md]: The FPA offers a reward to people fixing known bugs in FreeCAD (experimental program)
-* (Maintainers honorarium)[/_programs/maintainer_honorarium.md]: The FPA offers a honorarium to people doing active maintaining work
+* [Travel grants](_programs/FOSDEM_travel_grants.md): Travel grants for FreeCAD community members
+* [Development fund](_programs/FPADF_Announcement.md): The FPA offers grants to accelerate FreeCAD development
+* [Learning initiative](_programs/learning_initiative.md): A program for people willing to learn and teach FreeCAD
+* [Blog content](_programs/blog_content.md): The FPA seeks authors to write original content for the FreeCAD Blog
+* [Job offers](_programs/job_offers.md): The FPA seeks people interested in obtaining a grant to perform a specific task
+* [Bugfix rewards](_programs/bugfix_rewards_program.md): The FPA offers a reward to people fixing known bugs in FreeCAD (experimental program)
+* [Maintainers honorarium](_programs/maintainer_honorarium.md): The FPA offers a honorarium to people doing active maintaining work
 
 {% endif %}


### PR DESCRIPTION
## Summary

Fixed incorrect formatting of non-Jekyll links in `programs.md`

## Details

- the formatting was flipped with `(text)[link]` instead of `[text](link)`
- there was a space in between the bugfix rewards text and link
- used case-sensitive file names
- used relative links so that they work on local FS too

## Validation

- Tested in my local VSCode markdown reader
- Tested the rendered markdown in the [PR commit](https://github.com/agilgur5/FPA/blob/945c6c07c7185bea5eff7ac2e6691b95ca3822d1/programs.md)