### PR TITLE
fix(programs): add missing frontmatter to bugfix + maintainer pages

### DIFF
--- a/_programs/bugfix_rewards_program.md
+++ b/_programs/bugfix_rewards_program.md
@@ -1,6 +1,11 @@
+---
+title: "Bugfix Rewards Program"
+description:
+   "Rewards program to pay contributors who fix bugs"
+layout: default
+---
+
 # Bugfix Rewards Program
-
-
 
 The FreeCAD Project Association (FPA) is introducing an experimental rewards program to thank contributors who improve the reliability and stability of FreeCAD.
 

--- a/_programs/maintainer_honorarium.md
+++ b/_programs/maintainer_honorarium.md
@@ -1,3 +1,10 @@
+---
+title: "Maintainer Honorarium"
+description:
+   "Compensation for FreeCAD's Core Maintainer group"
+layout: default
+---
+
 ## Maintainer Honorarium
 
 This text establishes a trust-based honorarium mechanism to compensate members of FreeCAD’s Core Maintainer group for code review, release coordination, and similar efforts, while keeping documentation burdens to a minimum. As a rule, only Core Maintainers benefit from the program; maintainers of plugins and dependencies in the FreeCAD ecosystem (“Ecosystem Maintainers”) may also be included under the special provisions below.


### PR DESCRIPTION
## Summary

Add YAML frontmatter to Bugfix and Maintainer programs so that Jekyll creates their HTML and they do not 404

## Details

- the Bugfix Rewards Program and Maintainer Honorarium were missing YAML frontmatter
  - without this, they were 404'ing on the website at https://fpa.freecad.org/programs/bugfix-rewards-program and https://fpa.freecad.org/programs/maintainer-honorarium
  
## Validation

- Manually tested this running Jekyll locally to confirm that the respective links from the [Programs page](https://fpa.freecad.org/programs.html) don't 404 anymore