### PR TITLE
fix(jobs): use correct subheading in "How to Apply"

### DIFF
--- a/_programs/job_offers.md
+++ b/_programs/job_offers.md
@@ -20,17 +20,15 @@ Alongside the [Grants program](FPADF-Announcement.md), the FPA also sponsors spe
 
 There are no current open positions. Please consider [applying for a Grant](FPADF-Announcement.md)!
 
-#### **How to Apply**
+### How to Apply
 
 Interested candidates should submit:
 
-* A short proposal or cover letter outlining relevant experience and vision for the competition.  
-* Examples of prior community, event, or project coordination work.  
+* A short proposal or cover letter outlining relevant experience and vision for the competition.
+* Examples of prior community, event, or project coordination work.
 * (Optional) Links to CAD or FreeCAD-related content you’ve created.
 
 Applications should be sent to **fpa@freecad.org**.
-
-
 
 ## Eligibility
 


### PR DESCRIPTION
## Summary

Just a semantic / stylistic fix to a subheading, feel free to close if not interested in the change

## Details

- per HTML semantics and `markdownlint` [MD001](https://github.com/DavidAnson/markdownlint/blob/v0.40.0/doc/md001.md), should not skip heading levels from h2 to h4
  - use h3 instead, which should also make the bolding no longer necessary